### PR TITLE
Create configured disk_store if it doesn't exist

### DIFF
--- a/src/bksw_io.erl
+++ b/src/bksw_io.erl
@@ -37,6 +37,7 @@
 
 -export([
          disk_format_version/0,
+         ensure_disk_store/0,
          upgrade_disk_format/0
          ]).
 
@@ -346,6 +347,16 @@ read_format_version({ok, Bin}) ->
     Line1 = hd(re:split(Bin, "\n")),
     Token1 = hd(string:tokens(binary_to_list(Line1), " ")),
     list_to_integer(Token1).
+
+ensure_disk_store() ->
+    Root = bksw_conf:disk_store(),
+    ToEnsure = filename:join([Root, "placehold"]),
+    case filelib:is_dir(Root) of
+        true -> ?LOG_INFO("Found disk_store at ~s", [Root]);
+        false -> ?LOG_INFO("Disk store dir did not exist. creating disk_store at ~s", [Root])
+    end,
+    ok = filelib:ensure_dir(ToEnsure),
+    ok.
 
 upgrade_disk_format() ->
     upgrade_disk_format(disk_format_version()).

--- a/src/bksw_sup.erl
+++ b/src/bksw_sup.erl
@@ -41,6 +41,7 @@ reconfigure_server() ->
 %%===================================================================
 
 init(_Args) ->
+    bksw_io:ensure_disk_store(),
     bksw_io:upgrade_disk_format(),
     RestartStrategy = one_for_one,
     MaxRestarts = 1000,


### PR DESCRIPTION
This avoids a confusing crash if the configured disk_store does not
exist. The log messages will indicate when the disk_store is created
vs found. If we're unable to create the disk_store dir, the log
message will help the user figure out the cause.

ping @sdelano @marcparadise @manderson26 @hosh @oferrigni 
