### PR TITLE
bookshelf 1.1.0

### DIFF
--- a/rebar.config.lock
+++ b/rebar.config.lock
@@ -2,9 +2,12 @@
 
 {require_otp_vsn,"R1[56]B.*"}.
 {erl_dep_retries,10}.
-{deps,[{eper,".*",
+{deps,[{envy,".*",
+             {git,"git://github.com/manderson26/envy.git",
+                  "d62cb227b9000ee866c8bcc724ddf68d87621dea"}},
+       {eper,".*",
              {git,"git://github.com/massemanet/eper.git",
-                  "35636bc4de07bc803ea4fc9731fab005d0378c2b"}},
+                  "1bd0d0212a563c1249fb66e9acd5760be30ff438"}},
        {erlsom,".*",
                {git,"git://github.com/opscode/erlsom.git",
                     "c5ca9fca1257f563d78b048e35ac60832ec80584"}},
@@ -25,22 +28,22 @@
                    "169cffd94759e99e2e8870b125861a91e3c1482a"}},
        {mini_s3,".*",
                 {git,"git://github.com/opscode/mini_s3.git",
-                     "ddeaa30687918706eb70f2b380ecbc2d7fbe53d2"}},
+                     "ed42875aefe598e8a31145d1482ac08827c2e9f6"}},
        {mixer,".*",
               {git,"git://github.com/opscode/mixer.git",
                    "58ded93d5c47675899d8e5e1589270f340ea66c5"}},
        {mochiweb,".*",
-                 {git,"git://github.com/basho/mochiweb",
-                      "05b5b7eb7b830afbd9ba349a40bf40ba0462aa11"}},
+                 {git,"git://github.com/basho/mochiweb.git",
+                      "5e6e3e688dc9987a97e261431256e29671555c0b"}},
        {opscoderl_wm,".*",
                      {git,"git://github.com/opscode/opscoderl_wm.git",
-                          "bbfa553114d28e1f2936f71e911209242b3da429"}},
+                          "3b476ef251637ad41c7187f24e011f0a52bd0215"}},
        {rebar_lock_deps_plugin,".*",
                                {git,"git://github.com/seth/rebar_lock_deps_plugin.git",
                                     "758d1cf4cc79483e1fbaf2ea59ed9e9f76b4a012"}},
        {webmachine,".*",
-                   {git,"git://github.com/basho/webmachine",
-                        "4c441d0f0ca9e343601eb39c8dd2e2117b781dfc"}}]}.
+                   {git,"git://github.com/opscode/webmachine",
+                        "6ce70393009446191af4771671712ffa0f1c83eb"}}]}.
 {erl_opts,[debug_info,warnings_as_errors]}.
 {xref_checks,[exports_not_used,undefined_function_calls]}.
 {plugins,[rebar_lock_deps_plugin]}.

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -1,7 +1,7 @@
 {sys,[{lib_dirs,["../deps","apps"]},
       {erts,[{mod_cond,derived},{app_file,strip}]},
       {app_file,strip},
-      {rel,"bookshelf","1.0.3",
+      {rel,"bookshelf","1.1.0",
            [kernel,stdlib,sasl,crypto,public_key,ssl,inets,erlsom,mochiweb,
             webmachine,xmerl,ibrowse,lager,mini_s3,bookshelf,opscoderl_wm]},
       {rel,"start_clean",[],[kernel,stdlib]},


### PR DESCRIPTION
New deps:

```
envy
```

Updated deps:

  mochiweb
    2013-06-25 5e6e3e6 Roll version 1.5.1p6
    2013-06-11 c9fdaaa Merge branch 'klm-strip-header-values-take2' into 1.5
    2013-06-04 d19ec05 Adjust headers_test to fix failing test cases
    2013-06-03 a84e06e Do not treat headers with empty values as undefined

  eper
    2013-12-10 1bd0d02 cosmetic
    2013-12-06 2ad3cdc v0.75
    2013-12-06 3ae6aac fix broken watchdog:eunit
    2013-12-06 2054336 remove broken bread:sax function
    2013-12-06 2d13ecb xreffing
    2013-12-06 8b847d3 adding getopt.erl to quiet xref
    2013-12-05 5048c5d remove "-import"
    2013-12-05 eee3daa fix race condition in prfPrc state initializer
    2013-12-02 19fda18 drop attempt to handle linux 2.4 or older
    2013-12-02 6293d10 prfPrc fails to config unless collect is alled first
    2013-11-20 9c55d16 new rebar
    2013-11-20 29afc2e make docs
    2013-11-19 e987415 v0.74
    2013-11-19 e15a5e6 fix changelog generation
    2013-11-19 ba95437 make make release release
    2013-11-19 197095c fix R16 build error due to typo in rebar.config.script
    2013-11-14 af5752a v0.73
    2013-11-14 40bd03f Merge pull request #18 from massemanet/watchdog-fixes
    2013-11-14 04cb820 reworking of watchdog
    2013-11-05 11ae389 version 0.72
    2013-11-05 28643c5 fix mess I made of susan.potter's patch
    2013-10-28 33b60a0 phony changelog target
    2013-10-21 cce6685 bumped to 0.71
    2013-10-18 5e3943f rebar update
    2013-10-13 9365442 Remove crypto module deprecations
    2013-10-07 d80eabc bumped to 0.70
    2013-10-07 edcbd79 remove some dead code
    2013-10-07 4c68c70 Remove print_pid conf. Make default print_fun print pid and regname.
    2013-03-13 5133f50 disk_log info
    2013-10-06 312e8df fix typo in "buffered" doc
    2013-10-06 5acc472 documented print_fun

  mini_s3
    2013-11-21 ed42875 Merge pull request #10 from opscode/sf/ipv6
    2013-11-21 0907187 Add support for bracketed ipv6 address literals when generating URLs
    2013-11-21 1bb326f Use concrete for uniform Makefile goodness
    2013-10-17 a9243b3 Merge pull request #9 from opscode/of/OC-8549
    2013-09-18 d9fba3d Convert to envy

  webmachine
    2013-12-12 6ce7039 Merge remote-tracking branch 'opscode/dev-only-deps' into opscode
    2013-12-12 53e6706 Enhance rebar.config.script for dev only dependencies
    2013-12-06 31c2413 Merge branch 'ipv6' into opscode
    2013-11-21 c8ba411 Support IPv6 address literals when parsing Host header
    2013-12-05 457dbd1 Merge pull request #179 from NineFX/use-newer-otp-in-travis
    2013-12-05 909dae7 Update .travis.yml to use the most recent releases of Erlang OTP
    2013-11-23 619acb5 Merge pull request #176 from agx/fixes/error_logger
    2013-11-21 d884918 Make sure Reason is a string
    2013-11-04 77ba1d8 Merge pull request #173 from basho/encode-error-body-rebased
    2013-01-21 eb43b4e Encode the error response before sending it.
    2013-10-16 e5f8233 Roll webmachine version 1.10.5
    2013-10-16 21c8b25 Standardize on a rebar.config dep format to reduce conflicts
    2013-09-12 9cd03ae update meck to basho fork, version 0.8.1
    2013-09-08 34c42df Merge pull request #166 from basho/vinoski/r16-test-fixes
    2013-09-08 e0c1cbe fix unit tests for Erlang/OTP R16
    2013-08-23 a169963 Update meck dependency tag
    2013-08-23 ae929c0 Change app vsn setting to git rather than fixed version
    2013-08-16 fd2d626 Merge branch 'ms-integration-testing'
    2013-08-15 0b144b4 Change some webmachine include_lib statements to includes
    2013-08-15 421db37 Refactor authorized_b8 assert conditions
    2013-08-15 18689b3 Extend timeout and exit supervisor normally in etag_test
    2013-04-05 bc9801c Increase line coverage of webmachine unit and integration tests. The goal for this first round is to increase coverage of the decision core of webmachine. For each node on the v3 HTTP activity diagram there are one or more tests that reach that node.
    2013-08-16 339427b Merge branch 'klm-error-logging-revamp'
    2013-08-14 8194983 Rework Webmachine error logging to use the built-in log handler
    2013-08-07 9755d0c Merge pull request #161 from cmeiklejohn/csm-sockname
    2013-07-31 96ec4d2 Fix EUnit timeout misspecification for etag_test.erl
    2013-07-22 947b540 Fix some whitespace.
    2013-07-19 1d79e49 Expose local socket.
    2013-07-19 eaadbad Add dialyzer.
    2013-07-18 e9359c7 fix horked makefile
    2013-07-18 3d5b71b Roll version 1.10.3
    2013-07-18 2313a31 Merge pull request #160 from basho/pevm-fix-R15
    2013-07-18 fa47565 Switch from Makefile to rebar.config.script for old_hash define
    2013-07-18 5456301 reverse macro logic to favor forward compatability
    2013-07-11 3637ea2 Merge pull request #158 from basho/ss-avoid-localtime-to-universaltime
    2013-07-11 36adf13 Merge pull request #156 from basho/pevm-fix-R15
    2013-07-11 b6dcefc Add last_modified callback
    2013-07-11 79af7a0 Avoid DST-aware translation from localtime to GMT
    2013-07-10 90951b7 fix R15 compatibility
    2013-07-10 d7f82fa Merge pull request #155 from basho/pevm-r16-compat-rebased
    2013-07-08 9706887 change hash fns for R16B01 compat
    2013-06-25 bcd0b3e Roll webmachine vsn 1.10.2
    2013-06-18 09de776 Merge branch 'klm-update-mochiweb-dep'
    2013-06-18 315995b Peg webmachine to the 1.5.1p6 tag of mochiweb
    2013-06-17 6dd4269 Merge branch 'klm-reduce-request-overhead-rebased'
    2013-06-17 23a3317 Merge branch 'klm-handle-invalid-host-header'
    2013-06-17 5a41101 Update metadata initialization in metadata_test
    2012-11-26 d7dbbdd Replace use of dict with orddict in request records
    2012-11-26 f439563 Avoid keeping extra request state any longer than necessary
    2013-06-17 9afc41f Merge pull request #76 from campanja/r548-dont-swallow-crashes
    2013-06-12 3766560 Merge branch 'klm-flexible-error-responses'
    2013-05-09 ea8ae55 Allow responses for all HTTP errors to be customized
    2013-06-11 ec5f138 Merge branch 'klm-handle-empty-content-type'
    2013-06-10 8b90c05 Merge pull request #151 from djnym/remove-io-formats
    2013-06-10 8c1d1b8 Removing io:format/2 calls from log file processing
    2013-06-04 cbc62cc Treat empty content-type header value the same as if it were undefined
    2013-05-28 75c5793 Handle undefined request time values in performance log handler
    2013-05-20 d6774d5 Merge pull request #147 from basho/sbv-fix-respcode
    2013-05-20 3969b8e handle custom reason phrases as iolist() in make_code
    2013-05-20 2c13db1 fix wrq:response_code/1 to handle custom reason phrase
    2013-05-08 6914fef Merge pull request #142 from basho/ss-throw-body-away-when-delete
    2013-05-07 e655fd4 Return a 400 when a request includes an invalid host header
    2013-05-07 66e0112 Flush body when DELETE to keep alive connection
    2013-04-25 01f444c Merge pull request #141 from basho/custom-reason-phrase
    2012-10-16 c30f903 add doc directory to .gitignore
    2012-10-15 dedc573 allow apps to supply custom reason phrases for HTTP response codes
    2013-04-05 c3571bc Merge branch '1.10'
    2013-03-30 d705a49 Merge pull request #136 from chaslemley/rebar_config_old_dependency
    2013-03-28 dde2ac5 fix template rebar.config to specify correct webmachine version
    2013-03-25 fdf8650 Merge pull request #134 from basho/sbv-combine-sends
    2013-03-23 dc924f5 collapse 4 separate send calls into 1 in send_chunk
    2013-03-21 8b2cb4d Merge pull request #133 from nacmartin/patch-1
    2013-03-21 b796c50 Update demo, rebar.config to webmachine, "1.10.*"
    2013-03-14 45406fd Merge branch '1.10'
    2013-03-14 e65feec Merge branch '1.10'
    2012-06-01 cfb431d Add logging for when webmachine crashes when body exists.

  opscoderl_wm
    2013-12-12 3b476ef Merge pull request #9 from opscode/mp/upgrade-webmachine-oc-10.1.5.1
    2013-12-12 662f4cc webmachine to 10.1.5.2
    2013-12-12 7713656 add test to validate new log event handling
    2013-12-12 43c2b52 Merge pull request #8 from opscode/mp/upgrade-webmachine-oc-10.1.5.1
    2013-11-27 6f0f888 add handling for additional message types we may receive
    2013-12-11 a97e01f use opscode fork of webmachine
    2013-11-22 5f4bec5 Merge pull request #6 from opscode/sf/wm-1.10.5-compat
    2013-11-22 7a2d284 Make as_io more strict for generic formatting
    2013-11-22 e412a30 Add generated edoc for browsing on github
    2013-11-22 37964d7 Fix doc string for edoc
    2013-11-22 d61a5b9 Compatibility fix for webmachine 1.10.5
    2013-11-22 4f8b5e4 Use integer 200, not binary for log test data

ping @seth @sdelano @manderson26 @hosh @oferrigni 
